### PR TITLE
Pin juju terraform provider to 0.8.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 }


### PR DESCRIPTION
sunbeam-terraform fails with new versions of
juju terraform provider, see [1]. Pin the
version to 0.8.0 until [1] is fixed and released.

[1] https://github.com/juju/terraform-provider-juju/issues/310