### PR TITLE
Switch to rabbit 3.12

### DIFF
--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -37,6 +37,10 @@ resource "juju_application" "rabbitmq" {
   }
 
   units = var.scale
+
+  config = {
+    minimum-replicas = var.scale > 3 ? 3 : var.scale
+  }
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "mysql-router-channel" {
 
 variable "rabbitmq-channel" {
   description = "Operator channel for RabbitMQ deployment"
-  default     = "3.9/stable"
+  default     = "3.12/edge"
 }
 
 variable "ovn-channel" {


### PR DESCRIPTION
Switch to using rabbit from the 3.12/edge to take advantage of quorum queues.