### PR TITLE
workflow: deploy - drop channel override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,6 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
-          # Temporary workaround as config option enable-telemetry-notifications is
-          # available only on 2023.1/edge channel
-          echo '{"openstack-channel": "2023.1/edge"}' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve
           juju model-config -m openstack automatically-retry-hooks=true


### PR DESCRIPTION
Drop the workflow specific override from the deploy workflow, ensuring that we actually deploy and test with the default channels.