### PR TITLE
Change juju channel to 3.1/stable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.28-strict/stable
-          juju-channel: 3.2/stable
-          bootstrap-options: --agent-version=3.2.0
+          juju-channel: 3.1/stable
           microk8s-addons: hostpath-storage dns rbac metallb:10.64.140.40-10.64.140.49
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Github workflows uses juju 3.2/stable.
Change to juju 3.1/channel and drop
bootstrap options.