### PR TITLE
Add trust to nova mysql-router apps

### DIFF
--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -181,6 +181,7 @@ resource "juju_application" "nova-api-mysql-router" {
   count = var.name == "nova" ? 1 : 0
   name  = "nova-api-mysql-router"
   model = var.model
+  trust = true
 
   charm {
     name    = "mysql-router-k8s"
@@ -225,6 +226,7 @@ resource "juju_application" "nova-cell-mysql-router" {
   count = var.name == "nova" ? 1 : 0
   name  = "nova-cell-mysql-router"
   model = var.model
+  trust = true
 
   charm {
     name    = "mysql-router-k8s"


### PR DESCRIPTION
Nova differs from other apps in that it has multiple mysql-routers associated with it to allow for the multiple db relations it has. These are specified explicitly in the Terraform plan and were missing the "trust" that the other mysql-router apps have.