### PR TITLE
Switch to stable mysql channels

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,12 +20,12 @@ variable "openstack-channel" {
 
 variable "mysql-channel" {
   description = "Operator channel for MySQL deployment"
-  default     = "8.0/candidate"
+  default     = "8.0/stable"
 }
 
 variable "mysql-router-channel" {
   description = "Operator channel for MySQL router deployment"
-  default     = "8.0/candidate"
+  default     = "8.0/stable"
   type        = string
 }
 


### PR DESCRIPTION
Update defaults for mysql-router and mysql to use the 8.0/stable channel.