### PR TITLE
Bump vault charm revision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,7 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
-          # Temporary workaround as config option enable-telemetry-notifications is
-          # available only on 2023.1/edge channel
-          echo '{"openstack-channel": "2023.1/edge"}' > terraform.tfvars.json
+          echo '{"openstack-channel": "2023.1/candidate", "enable-vault": true, "enable-barbican": true}' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve
           juju model-config -m openstack automatically-retry-hooks=true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
           provider: microk8s
           channel: 1.28-strict/stable
           juju-channel: 3.2/stable
-          bootstrap-options: --agent-version=3.2.0
           microk8s-addons: hostpath-storage dns rbac metallb:10.64.140.40-10.64.140.49
       - name: Install dependencies
         run: |

--- a/main.tf
+++ b/main.tf
@@ -652,7 +652,7 @@ resource "juju_application" "vault" {
   charm {
     name     = "vault-k8s"
     channel  = var.vault-channel
-    revision = 32
+    revision = 44
     series   = "jammy"
   }
 


### PR DESCRIPTION
Enable vault and barbican as part of deploy workflow

(cherry picked from commit b5f932c3c5e4ef6c2ec3886799e3a1f2f8f885c5)