### PR TITLE
Bump vault charm revision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
+          echo '{"enable-vault": true, "enable-barbican": true}' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve
           juju model-config -m openstack automatically-retry-hooks=true

--- a/main.tf
+++ b/main.tf
@@ -652,7 +652,7 @@ resource "juju_application" "vault" {
   charm {
     name     = "vault-k8s"
     channel  = var.vault-channel
-    revision = 32
+    revision = 44
     series   = "jammy"
   }
 


### PR DESCRIPTION
Enable vault and barbican as part of deploy workflow

(cherry picked from commit b5f932c3c5e4ef6c2ec3886799e3a1f2f8f885c5)