### PR TITLE
Revert actions-operator to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup operator environment
-        # Use actions-operator@main once the below bugis fixed 
-        # https://github.com/charmed-kubernetes/actions-operator/issues/67
-        uses: charmed-kubernetes/actions-operator@f0f23fb5c81def7bf525a2940482191e4966a02a
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           channel: 1.28-strict/stable


### PR DESCRIPTION
actions-operator in github workflow is pointed
to certain commit due to bug [1]. The PR for the
bug is merged and so revert the actions-operator
to main

[1] https://github.com/charmed-kubernetes/actions-operator/issues/67