### PR TITLE
Remove mysql default constraints

### DIFF
--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -34,7 +34,7 @@ variable "revision" {
 variable "constraints" {
   description = "Constraints for MySQL K8S operator"
   type        = string
-  default     = "arch=amd64 mem=2048M"
+  default     = null
 }
 
 variable "scale" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,9 @@ variable "mysql-revision" {
 variable "mysql-config" {
   description = "Operator configs for MySQL deployment"
   type        = map(string)
-  default     = {}
+  default = {
+    "profile-limit-memory" = 2148
+  }
 }
 
 variable "mysql-router-channel" {


### PR DESCRIPTION
Mysql k8s operator introduced in latest stable the option `profile-limit-memory` that allows settings max memory for MySQL processes without using juju constraints (that will double the reservation on k8s)

Setting the default to 2148 MB (closest value to 2GiB(which is around 2147.5MB))