### PR TITLE
Update for 2024.2 Caracal Release

### DIFF
--- a/channels/edge.tfvars
+++ b/channels/edge.tfvars
@@ -1,6 +1,6 @@
 # Core channels for direct charm dependencies
-openstack-channel = "2023.2/edge"
-ovn-channel       = "23.09/edge"
+openstack-channel = "2024.1/edge"
+ovn-channel       = "24.03/edge"
 # Test with candidate for dependent projects
 mysql-channel                   = "8.0/candidate"
 mysql-router-channel            = "8.0/candidate"

--- a/main.tf
+++ b/main.tf
@@ -122,11 +122,39 @@ module "nova" {
   mysql                = module.mysql.name["nova"]
   keystone             = module.keystone.name
   keystone-cacerts     = module.keystone.name
-  ingress-internal     = juju_application.traefik.name
-  ingress-public       = juju_application.traefik-public.name
+  ingress-internal     = ""
+  ingress-public       = ""
   scale                = var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
   resource-configs     = var.nova-config
+}
+
+resource "juju_integration" "nova-to-ingress-public" {
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = module.nova.name
+    endpoint = "traefik-route-public"
+  }
+
+  application {
+    name     = juju_application.traefik-public.name
+    endpoint = "traefik-route"
+  }
+}
+
+resource "juju_integration" "nova-to-ingress-internal" {
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = module.nova.name
+    endpoint = "traefik-route-internal"
+  }
+
+  application {
+    name     = juju_application.traefik.name
+    endpoint = "traefik-route"
+  }
 }
 
 module "horizon" {

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -300,3 +300,10 @@ resource "juju_offer" "cert-distributor-offer" {
   endpoint         = "send-ca-cert"
   name             = "cert-distributor"
 }
+
+resource "juju_offer" "nova-offer" {
+  count            = var.name == "nova" ? 1 : 0
+  model            = var.model
+  application_name = juju_application.service.name
+  endpoint         = "nova-service"
+}

--- a/modules/openstack-api/outputs.tf
+++ b/modules/openstack-api/outputs.tf
@@ -32,3 +32,8 @@ output "cert-distributor-offer-url" {
   description = "URL of the cert distributor offer"
   value       = juju_offer.cert-distributor-offer[*].url
 }
+
+output "nova-offer-url" {
+  description = "URL of the nova offer"
+  value       = juju_offer.nova-offer[*].url
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,3 +49,8 @@ output "cert-distributor-offer-url" {
   description = "URL of the cert distributor offer"
   value       = one(module.keystone.cert-distributor-offer-url[*])
 }
+
+output "nova-offer-url" {
+  description = "URL of the nova service offer"
+  value       = one(module.nova.nova-offer-url[*])
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@
 variable "openstack-channel" {
   description = "Operator channel for OpenStack deployment"
   type        = string
-  default     = "2023.2/stable"
+  default     = "2024.1/stable"
 }
 
 variable "mysql-channel" {
@@ -102,7 +102,7 @@ variable "certificate-authority-config" {
 variable "ovn-channel" {
   description = "Operator channel for OVN deployment"
   type        = string
-  default     = "23.09/stable"
+  default     = "24.03/stable"
 }
 
 variable "ovn-central-channel" {
@@ -624,7 +624,7 @@ variable "magnum-config" {
 variable "ldap-channel" {
   description = "Operator channel for Keystone LDAP deployment"
   type        = string
-  default     = "2023.2/stable"
+  default     = "2024.1/stable"
 }
 
 variable "ldap-revision" {


### PR DESCRIPTION
Update all default variables and the edge testing configuration to point to Caracal release tracks for charms.