### PR TITLE
Add ingress relation to nova

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,8 +122,8 @@ module "nova" {
   mysql                = module.mysql.name["nova"]
   keystone             = module.keystone.name
   keystone-cacerts     = module.keystone.name
-  ingress-internal     = ""
-  ingress-public       = ""
+  ingress-internal     = juju_application.traefik.name
+  ingress-public       = juju_application.traefik-public.name
   scale                = var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
   resource-configs     = var.nova-config


### PR DESCRIPTION
nova-k8s adds ingress relation back [1]
So update the terraform to add back the ingress
relation to nova

[1] https://review.opendev.org/c/openstack/sunbeam-charms/+/916860