### PR TITLE
Integrate cinder-ceph:identity-credentials keystone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,6 +359,7 @@ module "cinder-ceph" {
   revision             = var.cinder-ceph-revision
   rabbitmq             = module.rabbitmq.name
   mysql                = module.mysql.name["cinder"]
+  keystone-credentials = module.keystone.name
   ingress-internal     = ""
   ingress-public       = ""
   scale                = var.ha-scale


### PR DESCRIPTION
Integrate cinder-ceph with keystone over
identity-credentials interface