### PR TITLE
Give glance permissions to manage k8s resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ module "glance" {
   charm                = "glance-k8s"
   name                 = "glance"
   model                = juju_model.sunbeam.name
+  trust                = true
   channel              = var.glance-channel == null ? var.openstack-channel : var.glance-channel
   revision             = var.glance-revision
   rabbitmq             = module.rabbitmq.name

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -27,6 +27,7 @@ terraform {
 resource "juju_application" "service" {
   name  = var.name
   model = var.model
+  trust = var.trust
 
   charm {
     name     = var.charm

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -52,6 +52,12 @@ variable "model" {
   type        = string
 }
 
+variable "trust" {
+  description = "Give charm rights to it's k8s resources"
+  type        = bool
+  default     = false
+}
+
 variable "rabbitmq" {
   description = "RabbitMQ operator to integrate with"
   type        = string


### PR DESCRIPTION
Add the ability to the openstack-api module to set charm's trust.