### PR TITLE
Integrate traefik-rgw with manual tls provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1019,6 +1019,21 @@ resource "juju_integration" "traefik-to-tls-provider" {
   }
 }
 
+resource "juju_integration" "traefik-rgw-to-tls-provider" {
+  count = (var.enable-ceph && var.enable-tls-for-rgw-endpoint) ? (var.traefik-to-tls-provider == null ? 0 : 1) : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = juju_application.traefik-rgw[count.index].name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = var.traefik-to-tls-provider
+    endpoint = "certificates"
+  }
+}
+
 resource "juju_application" "tempest" {
   count = var.enable-validation ? 1 : 0
   name  = "tempest"

--- a/variables.tf
+++ b/variables.tf
@@ -687,6 +687,11 @@ variable "enable-tls-for-internal-endpoint" {
   default     = false
 }
 
+variable "enable-tls-for-rgw-endpoint" {
+  description = "Enable TLS for traefik rgw"
+  type        = bool
+  default     = false
+}
 
 variable "enable-validation" {
   description = "Enable Tempest deployment"


### PR DESCRIPTION
Integrate traefik-rgw to manual tls provider
based on variable enable-tls-for-rgw-endpoint