### PR TITLE
Increase default mysql memory limit

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "mysql-config" {
   description = "Operator configs for MySQL deployment"
   type        = map(string)
   default = {
-    "profile-limit-memory" = 2148
+    "profile-limit-memory" = 3456
   }
 }
 


### PR DESCRIPTION
mysql-k8s update to rev 153 fixes a bug in computing the memory for buffers / max connection. More memory is needed to accomodate the openstack services.