### PR TITLE
Add storage directives to applications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve -var-file=channels/edge.tfvars
+          juju model-config -m openstack automatically-retry-hooks=true
           juju-wait -vw -m openstack -t 3600 -x cinder-ceph -r 3
       - name: Collect juju status
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,9 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
-          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true}' > terraform.tfvars.json
+          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve -var-file=channels/edge.tfvars
-          juju model-config -m openstack automatically-retry-hooks=true
           juju-wait -vw -m openstack -t 3600 -x cinder-ceph -r 3
       - name: Collect juju status
         if: always()

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.13.0"
+      version = "= 0.14.0"
     }
   }
 }
@@ -42,7 +42,7 @@ locals {
     octavia   = var.many-mysql && var.enable-octavia ? { "configs" : lookup(var.mysql-config-map, "octavia", {}), "storages" : lookup(var.mysql-storage-map, "octavia", {}) } : null,
     designate = var.many-mysql && var.enable-designate ? { "configs" : lookup(var.mysql-config-map, "designate", {}), "storages" : lookup(var.mysql-storage-map, "designate", {}) } : null,
     barbican  = var.many-mysql && var.enable-barbican ? { "configs" : lookup(var.mysql-config-map, "barbican", {}), "storages" : lookup(var.mysql-storage-map, "barbican", {}) } : null,
-    watcher  = var.many-mysql && var.enable-watcher ? { "configs" : lookup(var.mysql-config-map, "watcher", {}), "storages" : lookup(var.mysql-storage-map, "watcher", {}) } : null,
+    watcher   = var.many-mysql && var.enable-watcher ? { "configs" : lookup(var.mysql-config-map, "watcher", {}), "storages" : lookup(var.mysql-storage-map, "watcher", {}) } : null,
   }
   single-mysql = "mysql"
   mysql = {

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.13.0"
+      version = "= 0.14.0"
     }
   }
 }

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.13.0"
     }
   }
 }
@@ -38,6 +38,8 @@ resource "juju_application" "mysql" {
   }
 
   config = var.resource-configs
+
+  storage_directives = var.resource-storages
 
   units = var.scale
 }

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -54,6 +54,12 @@ variable "resource-configs" {
   default     = {}
 }
 
+variable "resource-storages" {
+  description = "Storage directives to set for mysql"
+  type        = map(string)
+  default     = {}
+}
+
 variable "logging-app" {
   description = "Name of application providing logging endpoint"
   type        = string

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.13.0"
+      version = "= 0.14.0"
     }
   }
 }

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.13.0"
     }
   }
 }
@@ -36,6 +36,8 @@ resource "juju_application" "service" {
   }
 
   config = var.resource-configs
+
+  storage_directives = var.resource-storages
 
   units = var.scale
 }

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -109,6 +109,12 @@ variable "resource-configs" {
   default     = {}
 }
 
+variable "resource-storages" {
+  description = "Storage directives to set for all resources"
+  type        = map(string)
+  default     = {}
+}
+
 variable "logging-app" {
   description = "Name of application providing logging endpoint"
   type        = string

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.13.0"
+      version = "= 0.14.0"
     }
   }
 }

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.13.0"
     }
   }
 }
@@ -34,8 +34,9 @@ resource "juju_application" "ovn-central" {
     revision = var.revision
   }
 
-  config = var.resource-configs
-  units  = var.scale
+  config             = var.resource-configs
+  storage_directives = var.resource-storages
+  units              = var.scale
 }
 
 resource "juju_application" "ovn-relay" {

--- a/modules/ovn/variables.tf
+++ b/modules/ovn/variables.tf
@@ -31,6 +31,12 @@ variable "resource-configs" {
   default     = {}
 }
 
+variable "resource-storages" {
+  description = "Operator storage directives for OVN Central"
+  type        = map(string)
+  default     = {}
+}
+
 variable "scale" {
   description = "Scale of OVN central application"
   type        = number

--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.13.0"
+      version = "= 0.14.0"
     }
   }
 }

--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.13.0"
     }
   }
 }
@@ -40,6 +40,8 @@ resource "juju_application" "rabbitmq" {
   config = merge(var.resource-configs, {
     minimum-replicas = var.scale > 3 ? 3 : var.scale
   })
+
+  storage_directives = var.resource-storages
 }
 
 

--- a/modules/rabbitmq/variables.tf
+++ b/modules/rabbitmq/variables.tf
@@ -43,7 +43,13 @@ variable "model" {
 }
 
 variable "resource-configs" {
-  description = "Configs to set for mysql"
+  description = "Configs to set for rabbitmq"
+  type        = map(string)
+  default     = {}
+}
+
+variable "resource-storages" {
+  description = "Storage directives to set for rabbitmq"
   type        = map(string)
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,20 @@ variable "mysql-config" {
   }
 }
 
+variable "mysql-storage" {
+  description = "Storage directives for MySQL deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "mysql-config-map" {
   description = "Operator configs for specific MySQL deployment (applied on top of mysql-config for specific application)"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "mysql-storage-map" {
+  description = "Operator storage directives for specific MySQL deployment (applied on top of mysql-storage for specific application)"
   type        = map(map(string))
   default     = {}
 }
@@ -69,6 +81,12 @@ variable "traefik-config" {
   default     = {}
 }
 
+variable "traefik-storage" {
+  description = "Operator storage directives for Traefik deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "rabbitmq-channel" {
   description = "Operator channel for RabbitMQ deployment"
   type        = string
@@ -83,6 +101,12 @@ variable "rabbitmq-revision" {
 
 variable "rabbitmq-config" {
   description = "Operator configs for RabbitMQ deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "rabbitmq-storage" {
+  description = "Operator storage directives for RabbitMQ deployment"
   type        = map(string)
   default     = {}
 }
@@ -129,6 +153,12 @@ variable "ovn-central-config" {
   default     = {}
 }
 
+variable "ovn-central-storage" {
+  description = "Operator storage directives for OVN Central deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "ovn-relay-channel" {
   description = "Operator channel for OVN Relay deployment"
   type        = string
@@ -165,6 +195,12 @@ variable "keystone-config" {
   default     = {}
 }
 
+variable "keystone-storage" {
+  description = "Operator storage directives for Keystone deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "glance-channel" {
   description = "Operator channel for Glance deployment"
   type        = string
@@ -179,6 +215,12 @@ variable "glance-revision" {
 
 variable "glance-config" {
   description = "Operator config for Glance deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "glance-storage" {
+  description = "Operator storage directives for Glance deployment"
   type        = map(string)
   default     = {}
 }
@@ -503,6 +545,12 @@ variable "octavia-config" {
   default     = {}
 }
 
+variable "octavia-storage" {
+  description = "Operator storage directives for Octavia deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "enable-designate" {
   description = "Enable OpenStack Designate service"
   type        = bool
@@ -575,6 +623,12 @@ variable "vault-revision" {
 
 variable "vault-config" {
   description = "Operator config for Vault deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vault-storage" {
+  description = "Operator storage directives for Vault deployment"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
Add storage_directive to mysql-k8s, keystone-k8s,
glance-k8s, octavia-k8s, ovn-central-k8s apps.
Add mysql-storage-map to set storage directives for each mysql application for multi-mysql
deployment.