### PR TITLE
Implement pebble log forwarding

### DIFF
--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -280,6 +280,21 @@ resource "juju_integration" "nova-cell-to-mysql-router" {
   }
 }
 
+resource "juju_integration" "service-to-logging" {
+  count = (var.logging-app != null) ? 1 : 0
+  model = var.model
+
+  application {
+    name     = juju_application.service.name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = var.logging-app
+    endpoint = "logging-provider"
+  }
+}
+
 resource "juju_offer" "keystone-offer" {
   count            = var.name == "keystone" ? 1 : 0
   model            = var.model

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -108,3 +108,9 @@ variable "resource-configs" {
   type        = map(string)
   default     = {}
 }
+
+variable "logging-app" {
+  description = "Name of application providing logging endpoint"
+  type        = string
+  default     = null
+}

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -99,6 +99,36 @@ resource "juju_integration" "ovn-relay-to-ca" {
   }
 }
 
+resource "juju_integration" "ovn-central-to-logging" {
+  count = (var.logging-app != null) ? 1 : 0
+  model = var.model
+
+  application {
+    name     = juju_application.ovn-central.name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = var.logging-app
+    endpoint = "logging-provider"
+  }
+}
+
+resource "juju_integration" "ovn-relay-to-logging" {
+  count = (var.logging-app != null) ? 1 : 0
+  model = var.model
+
+  application {
+    name     = juju_application.ovn-relay[0].name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = var.logging-app
+    endpoint = "logging-provider"
+  }
+}
+
 resource "juju_offer" "ovn-relay-offer" {
   count            = var.relay != "" ? 1 : 0
   model            = var.model

--- a/modules/ovn/variables.tf
+++ b/modules/ovn/variables.tf
@@ -77,3 +77,9 @@ variable "ca" {
   type        = string
   default     = ""
 }
+
+variable "logging-app" {
+  description = "Name of application providing logging endpoint"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
All OS API + OVN services now support the logging relation to forward the service logs to the logging provider.