### PR TITLE
Force ubuntu@24.04 for os/ovn charms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -754,6 +754,7 @@ resource "juju_application" "ceilometer" {
     name     = "ceilometer-k8s"
     channel  = var.ceilometer-channel == null ? var.openstack-channel : var.ceilometer-channel
     revision = var.ceilometer-revision
+    base     = "ubuntu@24.04"
   }
 
   config = merge(var.ceilometer-config, { region = var.region })
@@ -851,6 +852,7 @@ resource "juju_application" "openstack-exporter" {
     name     = "openstack-exporter-k8s"
     channel  = var.openstack-exporter-channel == null ? var.openstack-channel : var.openstack-exporter-channel
     revision = var.openstack-exporter-revision
+    base     = "ubuntu@24.04"
   }
 
   config = merge(var.openstack-exporter-config, { region = var.region })
@@ -997,6 +999,7 @@ resource "juju_application" "bind" {
     name     = "designate-bind-k8s"
     channel  = var.bind-channel
     revision = var.bind-revision
+    base     = "ubuntu@24.04"
   }
 
   config = var.bind-config
@@ -1161,6 +1164,7 @@ resource "juju_application" "ldap-apps" {
     name     = "keystone-ldap-k8s"
     channel  = var.ldap-channel
     revision = var.ldap-revision
+    base     = "ubuntu@24.04"
   }
   # This is a config charm so 1 unit is enough
   units  = 1
@@ -1266,6 +1270,7 @@ resource "juju_application" "tempest" {
     name     = "tempest-k8s"
     channel  = var.tempest-channel == null ? var.openstack-channel : var.tempest-channel
     revision = var.tempest-revision
+    base     = "ubuntu@24.04"
   }
 
   units  = 1
@@ -1400,6 +1405,7 @@ resource "juju_application" "images-sync" {
     name     = "openstack-images-sync-k8s"
     channel  = var.images-sync-channel == null ? var.openstack-channel : var.images-sync-channel
     revision = var.images-sync-revision
+    base     = "ubuntu@24.04"
   }
 
   units  = 1

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -33,6 +33,7 @@ resource "juju_application" "service" {
     name     = var.charm
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config = var.resource-configs

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -30,6 +30,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "Operator base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "mysql-router-channel" {
   description = "Operator channel for MySQL router deployment"
   type        = string

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -32,6 +32,7 @@ resource "juju_application" "ovn-central" {
     name     = "ovn-central-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config             = var.resource-configs
@@ -49,6 +50,7 @@ resource "juju_application" "ovn-relay" {
     name     = "ovn-relay-k8s"
     channel  = var.relay-channel
     revision = var.relay-revision
+    base     = var.base
   }
 
   config = var.relay-resource-configs

--- a/modules/ovn/variables.tf
+++ b/modules/ovn/variables.tf
@@ -25,6 +25,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "Operator base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "resource-configs" {
   description = "Operator config for OVN Central"
   type        = map(string)


### PR DESCRIPTION
All OpenStack (except tempest) and OVN charms have been migrated to ubuntu@24.04 base.