### PR TITLE
Make cloud region a variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "juju_model" "sunbeam" {
 
   cloud {
     name   = var.cloud
-    region = "localhost"
+    region = var.cloud-region
   }
 
   credential = var.credential

--- a/variables.tf
+++ b/variables.tf
@@ -345,6 +345,12 @@ variable "cloud" {
   default     = "microk8s"
 }
 
+variable "cloud-region" {
+  description = "Name of cloud region to use for deployment"
+  type        = string
+  default     = "localhost"
+}
+
 # https://github.com/juju/terraform-provider-juju/issues/147
 variable "credential" {
   description = "Name of credential to use for deployment"


### PR DESCRIPTION
This allows to run against a custom k8s cluster with another region name without having to modify terraform sources.