### PR TITLE
Add terraform plan for consul

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
-          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
+          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "enable-consul-management": true, "enable-consul-tenant": true, "enable-consul-storage": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve -var-file=channels/edge.tfvars
           juju model-config -m openstack automatically-retry-hooks=true

--- a/channels/edge.tfvars
+++ b/channels/edge.tfvars
@@ -11,3 +11,4 @@ manual-tls-certificates-channel = "latest/candidate"
 bind-channel                    = "9/edge"    # No candidate release
 vault-channel                   = "1.15/edge" # No candidate release
 grafana-agent-channel           = "latest/candidate"
+consul-channel                  = "1.19/edge" # No candidate release

--- a/main.tf
+++ b/main.tf
@@ -1504,3 +1504,39 @@ resource "juju_integration" "watcher-to-gnocchi" {
     endpoint = "gnocchi-db"
   }
 }
+
+module "consul-management" {
+  count             = var.enable-consul-management ? 1 : 0
+  source            = "./modules/consul"
+  model             = juju_model.sunbeam.name
+  name              = "consul-management"
+  scale             = var.ha-scale
+  channel           = var.consul-channel
+  revision          = var.consul-revision
+  resource-configs  = var.consul-config
+  resource-storages = var.consul-storage
+}
+
+module "consul-tenant" {
+  count             = var.enable-consul-tenant ? 1 : 0
+  source            = "./modules/consul"
+  model             = juju_model.sunbeam.name
+  name              = "consul-tenant"
+  scale             = var.ha-scale
+  channel           = var.consul-channel
+  revision          = var.consul-revision
+  resource-configs  = var.consul-config
+  resource-storages = var.consul-storage
+}
+
+module "consul-storage" {
+  count             = var.enable-consul-storage ? 1 : 0
+  source            = "./modules/consul"
+  model             = juju_model.sunbeam.name
+  name              = "consul-storage"
+  scale             = var.ha-scale
+  channel           = var.consul-channel
+  revision          = var.consul-revision
+  resource-configs  = var.consul-config
+  resource-storages = var.consul-storage
+}

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -1,0 +1,3 @@
+# Consul K8S Terraform module
+
+Deployment of Consul Charmed K8S Operators under Juju.

--- a/modules/consul/main.tf
+++ b/modules/consul/main.tf
@@ -1,0 +1,50 @@
+# Terraform module for deployment of RabbitMQ K8S
+#
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "= 0.14.0"
+    }
+  }
+}
+
+resource "juju_application" "consul" {
+  name  = var.name
+  trust = true
+  model = var.model
+
+  charm {
+    name     = "consul-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  units = var.scale
+
+  config = var.resource-configs
+
+  storage_directives = var.resource-storages
+}
+
+resource "juju_offer" "consul-cluster-offer" {
+  model            = var.model
+  application_name = var.name
+  endpoint         = "consul-cluster"
+}

--- a/modules/consul/outputs.tf
+++ b/modules/consul/outputs.tf
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "consul-cluster-offer-url" {
+  description = "URL of the Consul offer"
+  value       = juju_offer.consul-cluster-offer.url
+}

--- a/modules/consul/variables.tf
+++ b/modules/consul/variables.tf
@@ -1,0 +1,61 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" {
+  description = "Name of the deployed Consul K8S operator"
+  type        = string
+  default     = "consul"
+}
+
+variable "channel" {
+  description = "Consul K8S charm channel"
+  type        = string
+  default     = "1.19/edge"
+}
+
+variable "revision" {
+  description = "Consul K8S charm channel revision"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "Operator base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "scale" {
+  description = "Scale of Consul K8S charm"
+  type        = number
+  default     = 1
+}
+
+variable "model" {
+  description = "Juju model to deploy resources in"
+  type        = string
+}
+
+variable "resource-configs" {
+  description = "Configs to set for consul"
+  type        = map(string)
+  default     = {}
+}
+
+variable "resource-storages" {
+  description = "Storage directives to set for consul"
+  type        = map(string)
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,3 +64,18 @@ output "ingress-rgw-offer-url" {
   description = "URL of the RGW ingress offer"
   value       = one(juju_offer.ingress-rgw-offer[*].url)
 }
+
+output "consul-management-cluster-offer-url" {
+  description = "URL of the Consul Management cluster offer"
+  value       = one(module.consul-management[*].consul-cluster-offer-url)
+}
+
+output "consul-tenant-cluster-offer-url" {
+  description = "URL of the Consul Tenant cluster offer"
+  value       = one(module.consul-tenant[*].consul-cluster-offer-url)
+}
+
+output "consul-storage-cluster-offer-url" {
+  description = "URL of the Consul Storage cluster offer"
+  value       = one(module.consul-storage[*].consul-cluster-offer-url)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -843,6 +843,48 @@ variable "watcher-config" {
   default     = {}
 }
 
+variable "enable-consul-management" {
+  description = "Enable Consul to track clients running on management network"
+  type        = bool
+  default     = false
+}
+
+variable "enable-consul-tenant" {
+  description = "Enable Consul to track clients running on tenant network"
+  type        = bool
+  default     = false
+}
+
+variable "enable-consul-storage" {
+  description = "Enable Consul to track clients running on storage network"
+  type        = bool
+  default     = false
+}
+
+variable "consul-channel" {
+  description = "Operator channel for Consul K8S deployment"
+  type        = string
+  default     = null
+}
+
+variable "consul-revision" {
+  description = "Operator channel revision for Consul K8S deployment"
+  type        = number
+  default     = null
+}
+
+variable "consul-config" {
+  description = "Operator config for Consul K8S deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "consul-storage" {
+  description = "Operator storage directives for Consul K8S deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "region" {
   description = "Region name"
   type        = string


### PR DESCRIPTION
Add terraform module consul t deploy
consul-k8s and outputs the consul-cluster
offer url.
Add terraform plan for consul to deploy 3
consul k8s each for management, tenant, storage
network.