### PR TITLE
Add config map to get config for each consul instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1520,7 +1520,7 @@ module "consul-management" {
   scale             = var.ha-scale
   channel           = var.consul-channel
   revision          = var.consul-revision
-  resource-configs  = var.consul-config
+  resource-configs  = merge(var.consul-config, lookup(var.consul-config-map, "consul-management", {}))
   resource-storages = var.consul-storage
 }
 
@@ -1532,7 +1532,7 @@ module "consul-tenant" {
   scale             = var.ha-scale
   channel           = var.consul-channel
   revision          = var.consul-revision
-  resource-configs  = var.consul-config
+  resource-configs  = merge(var.consul-config, lookup(var.consul-config-map, "consul-tenant", {}))
   resource-storages = var.consul-storage
 }
 
@@ -1544,7 +1544,7 @@ module "consul-storage" {
   scale             = var.ha-scale
   channel           = var.consul-channel
   revision          = var.consul-revision
-  resource-configs  = var.consul-config
+  resource-configs  = merge(var.consul-config, lookup(var.consul-config-map, "consul-storage", {}))
   resource-storages = var.consul-storage
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -909,6 +909,12 @@ variable "consul-config" {
   default     = {}
 }
 
+variable "consul-config-map" {
+  description = "Operator configs for specific Consul deployment (applied on top of consul-config for specific application)"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "consul-storage" {
   description = "Operator storage directives for Consul K8S deployment"
   type        = map(string)


### PR DESCRIPTION
Currently all the 3 consul resources use the same
config from variable consul-config. Add consul-config-map to specify config for each instance of consul.