### PR TITLE
Remove nova to placement integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -525,21 +525,6 @@ resource "juju_integration" "neutron-to-ca" {
   }
 }
 
-# juju integrate nova placement
-resource "juju_integration" "nova-to-placement" {
-  model = juju_model.sunbeam.name
-
-  application {
-    name     = module.nova.name
-    endpoint = "placement"
-  }
-
-  application {
-    name     = module.placement.name
-    endpoint = "placement"
-  }
-}
-
 # juju integrate glance microceph
 resource "juju_integration" "glance-to-ceph" {
   count = length(data.juju_offer.microceph)


### PR DESCRIPTION
nova:placement is removed in charm nova [1] since
placement interface is not implemented. This is
corresponding change in terraform plans.

[1] https://review.opendev.org/c/openstack/sunbeam-charms/+/937420

Fixes: [LP#2097327](https://bugs.launchpad.net/sunbeam-terraform/+bug/2097327)