### PR TITLE
Set designate-bind-k8s trust to true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -994,6 +994,7 @@ resource "juju_integration" "octavia-to-ca" {
 resource "juju_application" "bind" {
   count = var.enable-designate ? 1 : 0
   name  = "bind"
+  trust = true
   model = juju_model.sunbeam.name
 
   charm {


### PR DESCRIPTION
designate-bind-k8s requires interaction with
k8s to create service of type loadbalancer.
Set the charm trust to true to allow interaction
with k8s.