### PR TITLE
Update juju terraform provider to v0.20.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }
@@ -420,7 +420,7 @@ resource "juju_offer" "ingress-rgw-offer" {
   count            = var.enable-ceph ? 1 : 0
   model            = juju_model.sunbeam.name
   application_name = juju_application.traefik-rgw[count.index].name
-  endpoint         = "traefik-route"
+  endpoints        = ["traefik-route"]
 }
 
 resource "juju_integration" "traefik-rgw-to-metrics-endpoint" {
@@ -621,7 +621,7 @@ resource "juju_offer" "cinder-volume-database-offer" {
   count            = var.enable-cinder-volume ? 1 : 0
   model            = juju_model.sunbeam.name
   application_name = juju_application.cinder-volume-mysql-router[count.index].name
-  endpoint         = "database"
+  endpoints        = ["database"]
 }
 
 resource "juju_integration" "cinder-to-cinder-volume" {
@@ -641,7 +641,7 @@ resource "juju_integration" "cinder-to-cinder-volume" {
 resource "juju_offer" "ca-offer" {
   model            = juju_model.sunbeam.name
   application_name = juju_application.certificate-authority.name
-  endpoint         = "certificates"
+  endpoints        = ["certificates"]
 }
 
 module "heat" {
@@ -852,7 +852,7 @@ resource "juju_offer" "ceilometer-offer" {
   count            = var.enable-telemetry ? 1 : 0
   model            = juju_model.sunbeam.name
   application_name = juju_application.ceilometer[count.index].name
-  endpoint         = "ceilometer-service"
+  endpoints        = ["ceilometer-service"]
 }
 
 resource "juju_application" "openstack-exporter" {
@@ -1393,6 +1393,7 @@ resource "juju_integration" "grafana-agent-to-receive-remote-write" {
 
   application {
     offer_url = var.receive-remote-write-offer-url
+    endpoint  = "receive-remote-write"
   }
 }
 
@@ -1647,5 +1648,5 @@ resource "juju_offer" "masakari-offer" {
   count            = var.enable-masakari ? 1 : 0
   model            = juju_model.sunbeam.name
   application_name = module.masakari[count.index].name
-  endpoint         = "masakari-service"
+  endpoints        = ["masakari-service"]
 }

--- a/modules/consul/main.tf
+++ b/modules/consul/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }
@@ -46,5 +46,5 @@ resource "juju_application" "consul" {
 resource "juju_offer" "consul-cluster-offer" {
   model            = var.model
   application_name = juju_application.consul.name
-  endpoint         = "consul-cluster"
+  endpoints        = ["consul-cluster"]
 }

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }
@@ -298,11 +298,15 @@ resource "juju_integration" "service-to-logging" {
   }
 }
 
+# As a workaroud for bug
+# https://github.com/juju/terraform-provider-juju/issues/787,
+# the endpoints for keystone application are not
+# exposed as single offer URL
 resource "juju_offer" "keystone-offer" {
   count            = var.name == "keystone" ? 1 : 0
   model            = var.model
   application_name = juju_application.service.name
-  endpoint         = "identity-credentials"
+  endpoints        = ["identity-credentials"]
   name             = "keystone-credentials"
 }
 
@@ -310,7 +314,7 @@ resource "juju_offer" "keystone-endpoints-offer" {
   count            = var.name == "keystone" ? 1 : 0
   model            = var.model
   application_name = juju_application.service.name
-  endpoint         = "identity-service"
+  endpoints        = ["identity-service"]
   name             = "keystone-endpoints"
 }
 
@@ -318,7 +322,7 @@ resource "juju_offer" "cert-distributor-offer" {
   count            = var.name == "keystone" ? 1 : 0
   model            = var.model
   application_name = juju_application.service.name
-  endpoint         = "send-ca-cert"
+  endpoints        = ["send-ca-cert"]
   name             = "cert-distributor"
 }
 
@@ -326,5 +330,5 @@ resource "juju_offer" "nova-offer" {
   count            = var.name == "nova" ? 1 : 0
   model            = var.model
   application_name = juju_application.service.name
-  endpoint         = "nova-service"
+  endpoints        = ["nova-service"]
 }

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }
@@ -136,5 +136,5 @@ resource "juju_offer" "ovn-relay-offer" {
   count            = var.relay != "" ? 1 : 0
   model            = var.model
   application_name = juju_application.ovn-relay[count.index].name
-  endpoint         = "ovsdb-cms-relay"
+  endpoints        = ["ovsdb-cms-relay"]
 }

--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.17.1"
+      version = "= 0.20.0"
     }
   }
 }
@@ -49,7 +49,7 @@ resource "juju_application" "rabbitmq" {
 resource "juju_offer" "rabbitmq-offer" {
   model            = var.model
   application_name = juju_application.rabbitmq.name
-  endpoint         = "amqp"
+  endpoints        = ["amqp"]
 }
 
 


### PR DESCRIPTION
Update juju terraform provider to v0.20.0
Use attribute endpoints in juju offer resource
instead of endpoint.

Maintain separate juju offer URLs for keystone
endpoints as a workaround for bug [1]

[1] https://github.com/juju/terraform-provider-juju/issues/787