### PR TITLE
Enable trusted dashboard by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1667,7 +1667,6 @@ resource "juju_offer" "masakari-offer" {
 }
 
 resource "juju_integration" "keystone-to-trusted-dashboard-endpoint" {
-  count = var.keystone-to-trusted-dashboard ? 1 : 0
   model = juju_model.sunbeam.name
 
   application {

--- a/variables.tf
+++ b/variables.tf
@@ -921,12 +921,6 @@ variable "region" {
   default     = "RegionOne"
 }
 
-variable "keystone-to-trusted-dashboard" {
-  description = "Enable trusted dashboard"
-  type        = bool
-  default     = false
-}
-
 variable "kratos-idp-channel" {
   description = "Operator channel for Kratos external integrator"
   type        = string


### PR DESCRIPTION
The identity feature is being converted in a core command. This change enables the keystone:trusted-dashboard horizon:trusted-dashboard relation by default.