### PR TITLE
Set different variable names for traefik endpoints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -349,7 +349,11 @@ resource "juju_application" "traefik-public" {
     revision = var.traefik-revision
   }
 
-  config             = var.traefik-config
+  config = (
+    var.traefik-public-config != {}
+    ? var.traefik-public-config
+    : var.traefik-config
+  )
   storage_directives = var.traefik-storage
   units              = var.ingress-scale
 }
@@ -411,7 +415,11 @@ resource "juju_application" "traefik-rgw" {
     revision = var.traefik-revision
   }
 
-  config             = var.traefik-config
+  config = (
+    var.traefik-rgw-config != {}
+    ? var.traefik-rgw-config
+    : var.traefik-config
+  )
   storage_directives = var.traefik-storage
   units              = var.ingress-scale
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,17 @@ variable "traefik-config" {
   default     = {}
 }
 
+variable "traefik-public-config" {
+  description = "Operator configs for Traefik public deployment"
+  type        = map(string)
+  default     = {}
+}
+variable "traefik-rgw-config" {
+  description = "Operator configs for Traefik rgw deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "traefik-storage" {
   description = "Operator storage directives for Traefik deployment"
   type        = map(string)


### PR DESCRIPTION
This PR adds 2 more variables so the 3 Traefik endpoints do not use the same `var.traefik-config`. Which updates all 3 applications with the same config, which overwrites the `external_hostname` config option