### PR TITLE
Adds Manila to the terraform plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,11 @@ jobs:
           sudo snap install --classic juju-wait
       - name: Apply terraform
         run: |
-          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "enable-consul-management": true, "enable-consul-tenant": true, "enable-consul-storage": true, "enable-masakari": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
+          echo '{"credential": "microk8s", "enable-vault": true, "enable-barbican": true, "enable-designate": true, "nameservers": "testing.github.", "enable-watcher": true, "enable-consul-management": true, "enable-consul-tenant": true, "enable-consul-storage": true, "enable-manila": true, "enable-manila-cephfs": true, "enable-masakari": true, "mysql-storage": { "database": "12G" }, "keystone-storage": { "fernet-keys": "6M", "credential-keys": "8M" } }' > terraform.tfvars.json
           terraform init
           terraform apply -auto-approve -var-file=channels/edge.tfvars
           juju model-config -m openstack automatically-retry-hooks=true
-          juju-wait -vw -m openstack -t 3600 -x cinder -x vault -x barbican -r 3
+          juju-wait -vw -m openstack -t 3600 -x cinder -x vault -x barbican -x manila -x manila-cephfs -r 3
       - name: Collect juju status
         if: always()
         run: |

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ locals {
     horizon   = var.many-mysql ? { "configs" : lookup(var.mysql-config-map, "horizon", {}), "storages" : lookup(var.mysql-storage-map, "horizon", {}) } : null,
     heat      = var.many-mysql && var.enable-heat ? { "configs" : lookup(var.mysql-config-map, "heat", {}), "storages" : lookup(var.mysql-storage-map, "heat", {}) } : null,
     magnum    = var.many-mysql && var.enable-magnum ? { "configs" : lookup(var.mysql-config-map, "magnum", {}), "storages" : lookup(var.mysql-storage-map, "magnum", {}) } : null,
+    manila    = var.many-mysql && var.enable-manila ? { "configs" : lookup(var.mysql-config-map, "manila", {}), "storages" : lookup(var.mysql-storage-map, "manila", {}) } : null,
     aodh      = var.many-mysql && var.enable-telemetry ? { "configs" : lookup(var.mysql-config-map, "aodh", {}), "storages" : lookup(var.mysql-storage-map, "aodh", {}) } : null,
     gnocchi   = var.many-mysql && var.enable-telemetry ? { "configs" : lookup(var.mysql-config-map, "gnocchi", {}), "storages" : lookup(var.mysql-storage-map, "gnocchi", {}) } : null,
     octavia   = var.many-mysql && var.enable-octavia ? { "configs" : lookup(var.mysql-config-map, "octavia", {}), "storages" : lookup(var.mysql-storage-map, "octavia", {}) } : null,
@@ -55,6 +56,11 @@ locals {
 data "juju_offer" "microceph" {
   count = var.enable-ceph ? 1 : 0
   url   = var.ceph-offer-url
+}
+
+data "juju_offer" "microceph-ceph-nfs" {
+  count = var.enable-ceph-nfs ? 1 : 0
+  url   = var.ceph-nfs-offer-url
 }
 
 data "juju_offer" "cinder-volume" {
@@ -1174,6 +1180,78 @@ module "magnum" {
     "cluster-user-trust" = "true"
     region               = var.region
   })
+}
+
+module "manila" {
+  depends_on           = [module.single-mysql, module.many-mysql]
+  count                = var.enable-manila ? 1 : 0
+  source               = "./modules/openstack-api"
+  charm                = "manila-k8s"
+  name                 = "manila"
+  model                = juju_model.sunbeam.name
+  channel              = var.manila-channel == null ? var.openstack-channel : var.manila-channel
+  revision             = var.manila-revision
+  rabbitmq             = module.rabbitmq.name
+  mysql                = local.mysql["manila"]
+  keystone             = module.keystone.name
+  keystone-cacerts     = module.keystone.name
+  ingress-internal     = juju_application.traefik.name
+  ingress-public       = juju_application.traefik-public.name
+  scale                = var.os-api-scale
+  mysql-router-channel = var.mysql-router-channel
+  logging-app          = local.grafana-agent-name
+  resource-configs = merge(var.manila-config, {
+    region = var.region
+  })
+}
+
+module "manila-cephfs" {
+  depends_on           = [module.single-mysql, module.many-mysql]
+  count                = var.enable-manila-cephfs ? 1 : 0
+  source               = "./modules/openstack-api"
+  charm                = "manila-cephfs-k8s"
+  name                 = "manila-cephfs"
+  model                = juju_model.sunbeam.name
+  channel              = var.manila-cephfs-channel == null ? var.openstack-channel : var.manila-cephfs-channel
+  revision             = var.manila-cephfs-revision
+  rabbitmq             = module.rabbitmq.name
+  mysql                = local.mysql["manila"]
+  keystone-credentials = module.keystone.name
+  ingress-internal     = ""
+  ingress-public       = ""
+  scale                = var.os-api-scale
+  mysql-router-channel = var.mysql-router-channel
+  logging-app          = local.grafana-agent-name
+}
+
+resource "juju_integration" "manila-cephfs-to-manila" {
+  count = (var.enable-manila && var.enable-manila-cephfs) ? 1 : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = module.manila-cephfs[count.index].name
+    endpoint = "manila"
+  }
+
+  application {
+    name     = module.manila[count.index].name
+    endpoint = "manila"
+  }
+}
+
+# juju integrate manila-cephfs:ceph-nfs microceph:ceph-nfs
+resource "juju_integration" "manila-cephfs-to-ceph" {
+  count = var.enable-manila-cephfs ? length(data.juju_offer.microceph-ceph-nfs) : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = module.manila-cephfs[count.index].name
+    endpoint = "ceph-nfs"
+  }
+
+  application {
+    offer_url = data.juju_offer.microceph-ceph-nfs[count.index].url
+  }
 }
 
 resource "juju_application" "ldap-apps" {

--- a/variables.tf
+++ b/variables.tf
@@ -363,10 +363,22 @@ variable "enable-ceph" {
   default     = false
 }
 
+variable "enable-ceph-nfs" {
+  description = "Enable Ceph NFS integration"
+  type        = bool
+  default     = false
+}
+
 variable "ceph-offer-url" {
   description = "Offer URL from microceph app"
   type        = string
   default     = "admin/controller.microceph"
+}
+
+variable "ceph-nfs-offer-url" {
+  description = "NFS offer URL from microceph app"
+  type        = string
+  default     = "admin/controller.microceph-ceph-nfs"
 }
 
 variable "ceph-osd-replication-count" {
@@ -712,6 +724,54 @@ variable "magnum-revision" {
 
 variable "magnum-config" {
   description = "Operator config for Magnum deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable-manila" {
+  description = "Enable OpenStack Manila service"
+  type        = bool
+  default     = false
+}
+
+variable "manila-channel" {
+  description = "Operator channel for Manila deployment"
+  type        = string
+  default     = null
+}
+
+variable "manila-revision" {
+  description = "Operator channel revision for Manila deployment"
+  type        = number
+  default     = null
+}
+
+variable "manila-config" {
+  description = "Operator config for Manila deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable-manila-cephfs" {
+  description = "Enable OpenStack CEPHFS storage backend for the Manila service"
+  type        = bool
+  default     = false
+}
+
+variable "manila-cephfs-channel" {
+  description = "Operator channel for the CEPHFS manila-share service"
+  type        = string
+  default     = null
+}
+
+variable "manila-cephfs-revision" {
+  description = "Operator channel revision for the CEPHFS manila-share service"
+  type        = number
+  default     = null
+}
+
+variable "manila-cephfs-config" {
+  description = "Operator config for the CEPHFS manila-share service"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
OpenStack Manila provides Shared Filesystems as a service.

The `manila-k8s` charm contains the control plane services, while the `manila-cephfs-k8s` charm can integrate with MicroCeph to provide Manila with the NFS storage backend.
