### PR TITLE
Add configurable base for juju_application charm blocks

### DIFF
--- a/channels/edge.tfvars
+++ b/channels/edge.tfvars
@@ -4,11 +4,11 @@ ovn-channel       = "25.03/edge"
 # Test with candidate for dependent projects
 mysql-channel                   = "8.0/candidate"
 mysql-router-channel            = "8.0/candidate"
-traefik-channel                 = "1.0/candidate"
+traefik-channel                 = "latest/candidate"
 rabbitmq-channel                = "3.12/candidate"
 certificate-authority-channel   = "1/candidate"
 manual-tls-certificates-channel = "1/candidate"
-bind-channel                    = "9/edge"    # No candidate release
-vault-channel                   = "1.15/edge" # No candidate release
-grafana-agent-channel           = "latest/candidate"
-consul-channel                  = "1.19/edge" # No candidate release
+bind-channel                    = "9/candidate"
+vault-channel                   = "1.18/candidate"
+opentelemetry-collector-channel = "2/candidate"
+consul-channel                  = "1.19/candidate"

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,7 @@ module "single-mysql" {
   scale                 = var.ha-scale
   resource-configs      = var.mysql-config
   resource-storages     = var.mysql-storage
+  base                  = var.mysql-base
   grafana-dashboard-app = local.observability-agent-name
   metrics-endpoint-app  = local.observability-agent-name
   logging-app           = local.observability-agent-name
@@ -124,6 +125,7 @@ module "many-mysql" {
   scale                 = var.ha-scale
   resource-configs      = merge(var.mysql-config, each.value.configs)
   resource-storages     = merge(var.mysql-storage, each.value.storages)
+  base                  = var.mysql-base
   grafana-dashboard-app = local.observability-agent-name
   metrics-endpoint-app  = local.observability-agent-name
   logging-app           = local.observability-agent-name
@@ -159,6 +161,8 @@ module "glance" {
   ingress-public                        = local.standard-public-traefik-name
   scale                                 = var.is-region-controller ? 0 : (var.enable-ceph ? var.os-api-scale : 1)
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.glance-config, {
     ceph-osd-replication-count     = var.ceph-osd-replication-count
@@ -182,6 +186,8 @@ module "keystone" {
   ingress-public       = local.controller-public-traefik-name
   scale                = var.is-secondary-region ? 0 : var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs = merge(var.keystone-config, {
     enable-telemetry-notifications = var.enable-telemetry
@@ -209,6 +215,8 @@ module "nova" {
   ingress-public                        = local.standard-public-traefik-name
   scale                                 = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.nova-config, {
     region = var.region
@@ -263,6 +271,8 @@ module "horizon" {
   ingress-public                      = local.controller-public-traefik-name
   scale                               = var.is-secondary-region ? 0 : var.os-api-scale
   mysql-router-channel                = var.mysql-router-channel
+  base                                = var.base
+  mysql-router-base                   = var.mysql-router-base
   logging-app                         = local.observability-agent-name
   resource-configs = merge(var.horizon-config, {
     plugins = jsonencode(var.horizon-plugins)
@@ -287,6 +297,8 @@ module "neutron" {
   ingress-public                        = local.standard-public-traefik-name
   scale                                 = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.neutron-config, {
     region = var.region
@@ -310,6 +322,8 @@ module "placement" {
   ingress-public                        = local.standard-public-traefik-name
   scale                                 = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.placement-config, {
     region = var.region
@@ -325,6 +339,7 @@ resource "juju_application" "traefik" {
     name     = "traefik-k8s"
     channel  = var.traefik-channel
     revision = var.traefik-revision
+    base     = var.traefik-base
   }
 
   config             = var.traefik-config
@@ -386,6 +401,7 @@ resource "juju_application" "traefik-public" {
     name     = "traefik-k8s"
     channel  = var.traefik-channel
     revision = var.traefik-revision
+    base     = var.traefik-base
   }
 
   config = (
@@ -452,6 +468,7 @@ resource "juju_application" "traefik-rgw" {
     name     = "traefik-k8s"
     channel  = var.traefik-channel
     revision = var.traefik-revision
+    base     = var.traefik-base
   }
 
   config = (
@@ -524,6 +541,7 @@ resource "juju_application" "certificate-authority" {
     name     = "self-signed-certificates"
     channel  = var.certificate-authority-channel
     revision = var.certificate-authority-revision
+    base     = var.base
   }
 
   config = merge(var.certificate-authority-config, {
@@ -665,6 +683,8 @@ module "cinder" {
   ingress-public                        = local.standard-public-traefik-name
   scale                                 = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.cinder-config, {
     region = var.region
@@ -681,6 +701,7 @@ resource "juju_application" "cinder-volume-mysql-router" {
   charm {
     name    = "mysql-router-k8s"
     channel = var.mysql-router-channel
+    base    = var.mysql-router-base
   }
 
   units = var.ha-scale
@@ -760,6 +781,8 @@ module "heat" {
   ingress-public                        = ""
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.heat-config, {
     region = var.region
@@ -815,6 +838,8 @@ module "aodh" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.aodh-config, {
     region = var.region
@@ -839,6 +864,8 @@ module "gnocchi" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.gnocchi-config, {
     ceph-osd-replication-count = var.ceph-osd-replication-count
@@ -868,7 +895,7 @@ resource "juju_application" "ceilometer" {
     name     = "ceilometer-k8s"
     channel  = var.ceilometer-channel == null ? var.openstack-channel : var.ceilometer-channel
     revision = var.ceilometer-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   config = merge(var.ceilometer-config, { region = var.region })
@@ -997,7 +1024,7 @@ resource "juju_application" "openstack-exporter" {
     name     = "openstack-exporter-k8s"
     channel  = var.openstack-exporter-channel == null ? var.openstack-channel : var.openstack-exporter-channel
     revision = var.openstack-exporter-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   config = merge(var.openstack-exporter-config, { region = var.region })
@@ -1131,6 +1158,8 @@ module "octavia" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.octavia-config, {
     region = var.region
@@ -1244,7 +1273,7 @@ resource "juju_application" "bind" {
     name     = "designate-bind-k8s"
     channel  = var.bind-channel
     revision = var.bind-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   config = var.bind-config
@@ -1285,6 +1314,8 @@ module "designate" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.designate-config, {
     "nameservers" = var.nameservers
@@ -1332,6 +1363,7 @@ resource "juju_application" "vault" {
     name     = "vault-k8s"
     channel  = var.vault-channel
     revision = var.vault-revision
+    base     = var.base
   }
 
   config             = var.vault-config
@@ -1360,6 +1392,8 @@ module "barbican" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.barbican-config, {
     region = var.region
@@ -1406,6 +1440,8 @@ module "ironic" {
   ingress-public       = local.standard-public-traefik-name
   scale                = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs = merge(var.ironic-config, {
     region = var.region
@@ -1428,6 +1464,8 @@ module "nova-ironic" {
   ingress-public       = ""
   scale                = var.is-region-controller ? 0 : 1
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs = merge(var.nova-ironic-config, {
   })
@@ -1450,6 +1488,8 @@ module "ironic-conductor" {
   ingress-public       = ""
   scale                = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs = merge(var.ironic-conductor-config, {
   })
@@ -1561,6 +1601,8 @@ module "nova-ironic-shards" {
   ingress-public       = ""
   scale                = var.is-region-controller ? 0 : 1
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs = merge(var.nova-ironic-config, {
   })
@@ -1613,6 +1655,8 @@ module "ironic-conductor-groups" {
   ingress-public       = ""
   scale                = var.is-region-controller ? 0 : var.os-api-scale
   mysql-router-channel = var.mysql-router-channel
+  base                 = var.base
+  mysql-router-base    = var.mysql-router-base
   logging-app          = local.observability-agent-name
   resource-configs     = merge(var.ironic-conductor-config, each.value)
 }
@@ -1641,7 +1685,7 @@ resource "juju_application" "neutron-baremetal-switch-config" {
     name     = "neutron-baremetal-switch-config-k8s"
     channel  = var.neutron-baremetal-switch-config-channel == null ? var.openstack-channel : var.neutron-baremetal-switch-config-channel
     revision = var.neutron-baremetal-switch-config-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   # This is a config charm so 1 unit is enough
@@ -1660,7 +1704,7 @@ resource "juju_application" "neutron-generic-switch-config" {
     name     = "neutron-generic-switch-config-k8s"
     channel  = var.neutron-generic-switch-config-channel == null ? var.openstack-channel : var.neutron-generic-switch-config-channel
     revision = var.neutron-generic-switch-config-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   # This is a config charm so 1 unit is enough
@@ -1721,6 +1765,8 @@ module "magnum" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.magnum-config, {
     "cluster-user-trust" = "true"
@@ -1747,6 +1793,8 @@ module "manila" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.manila-config, {
     region = var.region
@@ -1770,6 +1818,8 @@ module "manila-cephfs" {
   ingress-public              = ""
   scale                       = var.os-api-scale
   mysql-router-channel        = var.mysql-router-channel
+  base                        = var.base
+  mysql-router-base           = var.mysql-router-base
   logging-app                 = local.observability-agent-name
 }
 
@@ -1813,6 +1863,7 @@ resource "juju_application" "manila-data-mysql-router" {
   charm {
     name    = "mysql-router-k8s"
     channel = var.mysql-router-channel
+    base    = var.mysql-router-base
   }
 
   units = var.ha-scale
@@ -1853,7 +1904,7 @@ resource "juju_application" "ldap-apps" {
     name     = "keystone-ldap-k8s"
     channel  = var.ldap-channel
     revision = var.ldap-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
   # This is a config charm so 1 unit is enough
   units  = 1
@@ -1899,6 +1950,7 @@ resource "juju_application" "manual-tls-certificates" {
     name     = "manual-tls-certificates"
     channel  = var.manual-tls-certificates-channel
     revision = var.manual-tls-certificates-revision
+    base     = var.base
   }
 
   units  = 1 # does not scale
@@ -1974,7 +2026,7 @@ resource "juju_application" "tempest" {
     name     = "tempest-k8s"
     channel  = var.tempest-channel == null ? var.openstack-channel : var.tempest-channel
     revision = var.tempest-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   units  = 1
@@ -2081,7 +2133,7 @@ resource "juju_application" "observability-agent" {
 
   charm {
     name     = "opentelemetry-collector-k8s"
-    base     = "ubuntu@24.04"
+    base     = var.base
     channel  = var.opentelemetry-collector-channel
     revision = var.opentelemetry-collector-revision
   }
@@ -2142,7 +2194,7 @@ resource "juju_application" "images-sync" {
     name     = "openstack-images-sync-k8s"
     channel  = var.images-sync-channel == null ? var.openstack-channel : var.images-sync-channel
     revision = var.images-sync-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
 
   units  = 1
@@ -2273,6 +2325,8 @@ module "watcher" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.watcher-config, {
     enable-telemetry-notifications = var.enable-telemetry
@@ -2350,6 +2404,8 @@ module "masakari" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.masakari-config, {
     region = var.region
@@ -2427,6 +2483,8 @@ module "cloudkitty" {
   ingress-public                        = juju_application.traefik-public.name
   scale                                 = var.os-api-scale
   mysql-router-channel                  = var.mysql-router-channel
+  base                                  = var.base
+  mysql-router-base                     = var.mysql-router-base
   logging-app                           = local.observability-agent-name
   resource-configs = merge(var.cloudkitty-config, {
     region = var.region
@@ -2472,7 +2530,7 @@ resource "juju_application" "sso-openid-providers" {
     name     = "kratos-external-idp-integrator"
     channel  = var.kratos-idp-channel
     revision = var.kratos-idp-revision
-    base     = "ubuntu@22.04"
+    base     = var.kratos-idp-base
   }
   units  = 1
   config = each.value
@@ -2502,7 +2560,7 @@ resource "juju_application" "sso-saml2-providers" {
     name     = "keystone-saml-k8s"
     channel  = var.keystone-saml-channel == null ? var.openstack-channel : var.keystone-saml-channel
     revision = var.keystone-saml-revision
-    base     = "ubuntu@24.04"
+    base     = var.base
   }
   units  = 1
   config = each.value

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -35,6 +35,7 @@ resource "juju_application" "mysql" {
     name     = "mysql-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config = var.resource-configs

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -77,3 +77,9 @@ variable "metrics-endpoint-app" {
   type        = string
   default     = null
 }
+
+variable "base" {
+  description = "Operator base"
+  type        = string
+  default     = "ubuntu@22.04"
+}

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -51,6 +51,7 @@ resource "juju_application" "mysql-router" {
   charm {
     name    = "mysql-router-k8s"
     channel = var.mysql-router-channel
+    base    = var.mysql-router-base
   }
 
   units = var.scale
@@ -280,6 +281,7 @@ resource "juju_application" "nova-api-mysql-router" {
   charm {
     name    = "mysql-router-k8s"
     channel = var.mysql-router-channel
+    base    = var.mysql-router-base
   }
 
   units = var.scale
@@ -324,6 +326,7 @@ resource "juju_application" "nova-cell-mysql-router" {
   charm {
     name    = "mysql-router-k8s"
     channel = var.mysql-router-channel
+    base    = var.mysql-router-base
   }
 
   units = var.scale

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -36,6 +36,12 @@ variable "base" {
   default     = "ubuntu@24.04"
 }
 
+variable "mysql-router-base" {
+  description = "Operator base for MySQL router deployment"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
 variable "mysql-router-channel" {
   description = "Operator channel for MySQL router deployment"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -63,10 +63,34 @@ variable "mysql-router-channel" {
   type        = string
 }
 
+variable "base" {
+  description = "Default operator base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "mysql-base" {
+  description = "Operator base for MySQL K8S deployment"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "mysql-router-base" {
+  description = "Operator base for MySQL router deployment"
+  default     = "ubuntu@22.04"
+  type        = string
+}
+
 variable "traefik-channel" {
   description = "Operator channel for Traefik deployment"
   type        = string
   default     = "1.0/stable"
+}
+
+variable "traefik-base" {
+  description = "Operator base for Traefik deployment"
+  type        = string
+  default     = "ubuntu@20.04"
 }
 
 variable "traefik-revision" {
@@ -694,7 +718,7 @@ variable "enable-vault" {
 variable "vault-channel" {
   description = "Operator channel for Vault deployment"
   type        = string
-  default     = "1.16/stable"
+  default     = "1.18/stable"
 }
 
 variable "vault-revision" {
@@ -1152,6 +1176,12 @@ variable "kratos-idp-channel" {
   description = "Operator channel for Kratos external integrator"
   type        = string
   default     = "0.2/stable"
+}
+
+variable "kratos-idp-base" {
+  description = "Operator base for Kratos external integrator"
+  type        = string
+  default     = "ubuntu@22.04"
 }
 
 variable "kratos-idp-revision" {


### PR DESCRIPTION
Introduce variables to replace hardcoded base strings across all juju_application resources and modules:

- `base` (default: ubuntu@24.04): used by certificate-authority, ceilometer, openstack-exporter, bind, vault, neutron-*-switch-config, ldap-apps, manual-tls-certificates, tempest, observability-agent, images-sync, sso-saml2-providers; also passed to all openstack-api module calls
- `traefik-base` (default: ubuntu@20.04): used by traefik, traefik-public, traefik-rgw
- `mysql-base` (default: ubuntu@22.04): passed to single-mysql and many-mysql module calls
- `mysql-router-base` (default: ubuntu@22.04): used by cinder-volume-mysql-router, manila-data-mysql-router, and all mysql-router resources in the openstack-api module (also passed through from root variables.tf to all openstack-api module calls)
- `kratos-idp-base` (default: ubuntu@22.04): used by sso-openid-providers

New variables in modules/mysql/variables.tf:
- `base` (default: ubuntu@22.04): used by mysql-k8s charm

New variables in modules/openstack-api/variables.tf:
- `mysql-router-base` (default: ubuntu@22.04): used by mysql-router, nova-api-mysql-router, nova-cell-mysql-router charms