### PR TITLE
traefik: specify configs separately for traefik apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -342,7 +342,7 @@ resource "juju_application" "traefik" {
     base     = var.traefik-base
   }
 
-  config             = var.traefik-config
+  config             = merge(var.traefik-config, lookup(var.traefik-config-map, "traefik", {}))
   storage_directives = var.traefik-storage
   units              = var.ingress-scale
 }
@@ -404,10 +404,9 @@ resource "juju_application" "traefik-public" {
     base     = var.traefik-base
   }
 
-  config = (
-    var.traefik-public-config != {}
-    ? var.traefik-public-config
-    : var.traefik-config
+  config = merge(
+    var.traefik-public-config != {} ? var.traefik-public-config : var.traefik-config,
+    lookup(var.traefik-config-map, "traefik-public", {})
   )
   storage_directives = var.traefik-storage
   units              = var.ingress-scale
@@ -471,10 +470,9 @@ resource "juju_application" "traefik-rgw" {
     base     = var.traefik-base
   }
 
-  config = (
-    var.traefik-rgw-config != {}
-    ? var.traefik-rgw-config
-    : var.traefik-config
+  config = merge(
+    var.traefik-rgw-config != {} ? var.traefik-rgw-config : var.traefik-config,
+    lookup(var.traefik-config-map, "traefik-rgw", {})
   )
   storage_directives = var.traefik-storage
   units              = var.ingress-scale

--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,12 @@ variable "traefik-rgw-config" {
   default     = {}
 }
 
+variable "traefik-config-map" {
+  description = "Operator configs for specific Traefik deployment (applied on top of traefik-config for specific application)"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "traefik-storage" {
   description = "Operator storage directives for Traefik deployment"
   type        = map(string)


### PR DESCRIPTION
currently traefik configs can be applied by using
variable traefik-config but this is applied on all the traefik apps i.e., traefik, traefif-public,
traefik-rgw.
Add new variable traefik-config-map where the variable can have configs per traefik application. This approach is similar to mysql-config-map.

Assisted-by: Claude:claude-4.6-sonnet