### PR TITLE
Set 2026.1 as default channels

### DIFF
--- a/channels/edge.tfvars
+++ b/channels/edge.tfvars
@@ -1,6 +1,6 @@
 # Core channels for direct charm dependencies
-openstack-channel = "2025.1/edge"
-ovn-channel       = "25.03/edge"
+openstack-channel = "2026.1/edge"
+ovn-channel       = "26.03/edge"
 # Test with candidate for dependent projects
 mysql-channel                   = "8.0/candidate"
 mysql-router-channel            = "8.0/candidate"
@@ -12,3 +12,5 @@ bind-channel                    = "9/candidate"
 vault-channel                   = "1.18/candidate"
 opentelemetry-collector-channel = "2/candidate"
 consul-channel                  = "1.19/candidate"
+ldap-channel                    = "2026.1/edge"
+cloudkitty-channel              = "2026.1/edge"

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,21 @@ resource "juju_integration" "nova-to-ingress-internal" {
   }
 }
 
+resource "juju_integration" "nova-to-ingress-metadata" {
+  count      = var.is-region-controller ? 0 : 1
+  model_uuid = juju_model.sunbeam.uuid
+
+  application {
+    name     = module.nova.name
+    endpoint = "ingress-metadata"
+  }
+
+  application {
+    name     = juju_application.traefik.name
+    endpoint = "ingress"
+  }
+}
+
 module "horizon" {
   depends_on                          = [module.single-mysql, module.many-mysql]
   source                              = "./modules/openstack-api"

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@
 variable "openstack-channel" {
   description = "Operator channel for OpenStack deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "mysql-channel" {
@@ -173,7 +173,7 @@ variable "certificate-authority-config" {
 variable "ovn-channel" {
   description = "Operator channel for OVN deployment"
   type        = string
-  default     = "24.03/stable"
+  default     = "26.03/stable"
 }
 
 variable "ovn-central-channel" {
@@ -959,7 +959,7 @@ variable "manila-cephfs-config" {
 variable "ldap-channel" {
   description = "Operator channel for Keystone LDAP deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "ldap-revision" {
@@ -1269,7 +1269,7 @@ variable "enable-cloudkitty" {
 variable "cloudkitty-channel" {
   description = "Operator channel for Cloudkitty deployment"
   type        = string
-  default     = "2025.1/edge"
+  default     = "2026.1/stable"
 }
 
 variable "cloudkitty-revision" {


### PR DESCRIPTION
Move the default OpenStack, OVN, LDAP, and Cloudkitty channels to the 2026.1/Gazpacho tracks.

Update the edge tfvars so local edge deployments consume 2026.1 charms while preserving refreshed main branch dependency channels.

Add the nova ingress-metadata relation to traefik-internal so 2026.1 deployments wire nova metadata ingress correctly.