### PR TITLE
Add glance horizon cors-origin relation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -699,6 +699,21 @@ resource "juju_integration" "glance-to-ceph" {
   }
 }
 
+# juju integrate horizon glance:cors-origin
+resource "juju_integration" "horizon-to-glance-cors-origin" {
+  model_uuid = juju_model.sunbeam.uuid
+
+  application {
+    name     = module.horizon.name
+    endpoint = "cors-origin"
+  }
+
+  application {
+    name     = module.glance.name
+    endpoint = "cors-origin"
+  }
+}
+
 module "cinder" {
   depends_on                            = [module.single-mysql, module.many-mysql]
   source                                = "./modules/openstack-api"


### PR DESCRIPTION
This change is not backward compatible because it depends on the charm updates in the following patch. These changes will need to be in tandem.

Depends on
- [x] https://review.opendev.org/c/openstack/sunbeam-charms/+/993785