### PR TITLE
fix: add missing enable-telemetry-notifications var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,8 @@ module "nova" {
   mysql-router-grafana-dashboard-app    = local.observability-agent-infra-name
   mysql-router-metrics-endpoint-app     = local.observability-agent-infra-name
   resource-configs = merge(var.nova-config, {
-    region = var.region
+    enable-telemetry-notifications = var.enable-telemetry
+    region                         = var.region
   })
 }
 
@@ -333,7 +334,8 @@ module "neutron" {
   mysql-router-grafana-dashboard-app    = local.observability-agent-infra-name
   mysql-router-metrics-endpoint-app     = local.observability-agent-infra-name
   resource-configs = merge(var.neutron-config, {
-    region = var.region
+    enable-telemetry-notifications = var.enable-telemetry
+    region                         = var.region
   })
 }
 
@@ -699,7 +701,8 @@ module "cinder" {
   mysql-router-grafana-dashboard-app    = local.observability-agent-infra-name
   mysql-router-metrics-endpoint-app     = local.observability-agent-infra-name
   resource-configs = merge(var.cinder-config, {
-    region = var.region
+    enable-telemetry-notifications = var.enable-telemetry
+    region                         = var.region
   })
 }
 
@@ -845,7 +848,8 @@ module "heat" {
   mysql-router-grafana-dashboard-app    = local.observability-agent-infra-name
   mysql-router-metrics-endpoint-app     = local.observability-agent-infra-name
   resource-configs = merge(var.heat-config, {
-    region = var.region
+    enable-telemetry-notifications = var.enable-telemetry
+    region                         = var.region
   })
 }
 
@@ -1922,7 +1926,8 @@ module "manila" {
   mysql-router-grafana-dashboard-app    = local.observability-agent-infra-name
   mysql-router-metrics-endpoint-app     = local.observability-agent-infra-name
   resource-configs = merge(var.manila-config, {
-    region = var.region
+    enable-telemetry-notifications = var.enable-telemetry
+    region                         = var.region
   })
 }
 


### PR DESCRIPTION
Add enable-telemetry-notifications variable to the resource-configs merge block for nova, neutron, cinder, heat, and manila modules. This ensures these services render [oslo_messaging_notifications] driver = messagingv2 when telemetry is enabled, matching the existing pattern for glance and keystone.

This change depends on the following charm change:
https://review.opendev.org/c/openstack/sunbeam-charms/+/1000794

Partial-bug: [#2162762](https://bugs.launchpad.net/snap-openstack/+bug/2162762)

## QA steps

1. Build the openstack snap with this branch
   - In `snap/snapcraft.yaml`, set `source-branch: bug/2162762` for the `terraform-openstack-plan` part
2. Deploy sunbeam
3. Enable telemetry and verify the config was propagated to all services
```
sunbeam enable telemetry
juju config nova enable-telemetry-notifications         # should be true
juju config neutron enable-telemetry-notifications      # should be true
juju config cinder enable-telemetry-notifications       # should be true
juju config heat enable-telemetry-notifications         # should be true
```
4. Verify config is false after disabling telemetry
```
sunbeam disable telemetry
juju config nova enable-telemetry-notifications         # should be false
```

## Links
**Jira card:** [OPEN-4670](https://warthogs.atlassian.net/browse/OPEN-4670)

[OPEN-4670]: https://warthogs.atlassian.net/browse/OPEN-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ